### PR TITLE
Make Email and Address optional

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -76,7 +76,7 @@ Format: `help`
 
 Adds a person to the address book.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​`
+Format: `add n/NAME p/PHONE_NUMBER [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 A person can have any number of tags (including 0)
@@ -85,6 +85,7 @@ A person can have any number of tags (including 0)
 Examples:
 * `add n/John Doe, Alexander p/98765432 e/johnd@example.com a/John street, block 123, #01-01`
 * `add n/Betsy d/o Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/+651234567 t/criminal`
+* `add n/Mary Jane t/friend p/+651234567`
 
 ### Listing all persons : `list`
 
@@ -193,7 +194,7 @@ _Details coming soon ..._
 
 Action | Format, Examples
 --------|------------------
-**Add** | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
+**Add** | `add n/NAME p/PHONE_NUMBER [e/EMAIL] [a/ADDRESS] [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
 **Clear** | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
 **Edit** | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -40,9 +40,9 @@ public class Messages {
                 .append("; Phone: ")
                 .append(person.getPhone())
                 .append("; Email: ")
-                .append(person.getEmail())
+                .append(person.getEmail().getValueForUI())
                 .append("; Address: ")
-                .append(person.getAddress())
+                .append(person.getAddress().getValueForUI())
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.OptionalField;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -33,7 +34,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
@@ -41,8 +42,21 @@ public class AddCommandParser implements Parser<AddCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+
+        Email email;
+        if (arePrefixesPresent(argMultimap, PREFIX_EMAIL)) {
+            email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+        } else {
+            email = Email.createEmpty();
+        }
+
+        Address address;
+        if (arePrefixesPresent(argMultimap, PREFIX_ADDRESS)) {
+            address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        } else {
+            address = Address.createEmpty();
+        }
+
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Person person = new Person(name, phone, email, address, tagList);
@@ -57,5 +71,4 @@ public class AddCommandParser implements Parser<AddCommand> {
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -15,7 +15,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
-import seedu.address.model.person.OptionalField;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Person's address in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
  */
-public class Address {
+public class Address implements OptionalField {
 
     public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
 
@@ -31,6 +31,28 @@ public class Address {
     }
 
     /**
+     * Constructs an empty {@code Address}.
+     * Package-private.
+     */
+    Address() {
+        value = null;
+    }
+
+    /**
+     * Returns an empty {@code Address}.
+     */
+    public static Address createEmpty() {
+        return EmptyAddress.get();
+    }
+
+    /**
+     * Returns false
+     */
+    public boolean isEmpty() {
+        return false;
+    }
+
+    /**
      * Returns true if a given string is a valid email.
      */
     public static boolean isValidAddress(String test) {
@@ -39,6 +61,14 @@ public class Address {
 
     @Override
     public String toString() {
+        return value;
+    }
+
+    /**
+     * Returns the String to be presented on the UI.
+     */
+    @Override
+    public String getValueForUI() {
         return value;
     }
 

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Person's email in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
  */
-public class Email implements OptionalField{
+public class Email implements OptionalField {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Person's email in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
  */
-public class Email {
+public class Email implements OptionalField{
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
@@ -45,6 +45,28 @@ public class Email {
     }
 
     /**
+     * Constructs an empty {@code Email}.
+     * Package-private.
+     */
+    Email() {
+        value = null;
+    }
+
+    /**
+     * Returns an empty {@code Email}.
+     */
+    public static Email createEmpty() {
+        return EmptyEmail.get();
+    }
+
+    /**
+     * Returns false
+     */
+    public boolean isEmpty() {
+        return false;
+    }
+
+    /**
      * Returns if a given string is a valid email.
      */
     public static boolean isValidEmail(String test) {
@@ -53,6 +75,14 @@ public class Email {
 
     @Override
     public String toString() {
+        return value;
+    }
+
+    /**
+     * Returns the String to be presented on the UI.
+     */
+    @Override
+    public String getValueForUI() {
         return value;
     }
 

--- a/src/main/java/seedu/address/model/person/EmptyAddress.java
+++ b/src/main/java/seedu/address/model/person/EmptyAddress.java
@@ -1,0 +1,43 @@
+package seedu.address.model.person;
+
+/**
+ * Represents an empty Address of a Person in the address book.
+ * Guarantees: immutable
+ */
+class EmptyAddress extends Address {
+
+    private static final EmptyAddress emptyAddress = new EmptyAddress();
+    public static final String INTERNAL_REPRESENTATION = "<REPRESENTATION FOR EMPTY ADDRESS>";
+
+    private EmptyAddress() {
+        super();
+    }
+
+    /**
+     * Provides an object representing an empty email.
+     */
+    public static EmptyAddress get() {
+        return emptyAddress;
+    }
+
+    /**
+     * Returns true
+     */
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return INTERNAL_REPRESENTATION;
+    }
+
+    /**
+     * Returns the String to be presented on the UI.
+     */
+    @Override
+    public String getValueForUI() {
+        return "No address provided";
+    }
+}

--- a/src/main/java/seedu/address/model/person/EmptyAddress.java
+++ b/src/main/java/seedu/address/model/person/EmptyAddress.java
@@ -7,6 +7,7 @@ package seedu.address.model.person;
 class EmptyAddress extends Address {
 
     private static final EmptyAddress emptyAddress = new EmptyAddress();
+
     public static final String INTERNAL_REPRESENTATION = "<REPRESENTATION FOR EMPTY ADDRESS>";
 
     private EmptyAddress() {

--- a/src/main/java/seedu/address/model/person/EmptyAddress.java
+++ b/src/main/java/seedu/address/model/person/EmptyAddress.java
@@ -6,9 +6,9 @@ package seedu.address.model.person;
  */
 class EmptyAddress extends Address {
 
-    private static final EmptyAddress emptyAddress = new EmptyAddress();
-
     public static final String INTERNAL_REPRESENTATION = "<REPRESENTATION FOR EMPTY ADDRESS>";
+
+    private static final EmptyAddress emptyAddress = new EmptyAddress();
 
     private EmptyAddress() {
         super();

--- a/src/main/java/seedu/address/model/person/EmptyEmail.java
+++ b/src/main/java/seedu/address/model/person/EmptyEmail.java
@@ -1,0 +1,46 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents an empty Email of a Person in the address book.
+ * Guarantees: immutable
+ */
+class EmptyEmail extends Email {
+
+    private static final EmptyEmail emptyEmail = new EmptyEmail();
+    public static final String INTERNAL_REPRESENTATION = "<REPRESENTATION FOR EMPTY EMAIL>";
+
+    private EmptyEmail() {
+        super();
+    }
+
+    /**
+     * Provides an object representing an empty email.
+     */
+    public static EmptyEmail get() {
+        return emptyEmail;
+    }
+
+    /**
+     * Returns true
+     */
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return INTERNAL_REPRESENTATION;
+    }
+
+    /**
+     * Returns the String to be presented on the UI.
+     */
+    @Override
+    public String getValueForUI() {
+        return "No email provided";
+    }
+}

--- a/src/main/java/seedu/address/model/person/EmptyEmail.java
+++ b/src/main/java/seedu/address/model/person/EmptyEmail.java
@@ -6,9 +6,9 @@ package seedu.address.model.person;
  */
 class EmptyEmail extends Email {
 
-    private static final EmptyEmail emptyEmail = new EmptyEmail();
-
     public static final String INTERNAL_REPRESENTATION = "<REPRESENTATION FOR EMPTY EMAIL>";
+
+    private static final EmptyEmail emptyEmail = new EmptyEmail();
 
     private EmptyEmail() {
         super();

--- a/src/main/java/seedu/address/model/person/EmptyEmail.java
+++ b/src/main/java/seedu/address/model/person/EmptyEmail.java
@@ -1,8 +1,5 @@
 package seedu.address.model.person;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
-
 /**
  * Represents an empty Email of a Person in the address book.
  * Guarantees: immutable
@@ -10,6 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 class EmptyEmail extends Email {
 
     private static final EmptyEmail emptyEmail = new EmptyEmail();
+
     public static final String INTERNAL_REPRESENTATION = "<REPRESENTATION FOR EMPTY EMAIL>";
 
     private EmptyEmail() {

--- a/src/main/java/seedu/address/model/person/OptionalField.java
+++ b/src/main/java/seedu/address/model/person/OptionalField.java
@@ -1,5 +1,8 @@
 package seedu.address.model.person;
 
+/**
+ * The API of an OptionalField that could contain nothing as a value.
+ */
 public interface OptionalField {
     boolean isEmpty();
     String getValueForUI();

--- a/src/main/java/seedu/address/model/person/OptionalField.java
+++ b/src/main/java/seedu/address/model/person/OptionalField.java
@@ -1,0 +1,6 @@
+package seedu.address.model.person;
+
+public interface OptionalField {
+    boolean isEmpty();
+    String getValueForUI();
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -16,7 +16,6 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
-import javax.swing.text.html.Option;
 
 /**
  * Jackson-friendly version of {@link Person}.

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -16,6 +16,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
+import javax.swing.text.html.Option;
 
 /**
  * Jackson-friendly version of {@link Person}.
@@ -23,6 +24,8 @@ import seedu.address.model.tag.Tag;
 class JsonAdaptedPerson {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
+
+    public static final String EMPTY_FIELD_FORMAT = "%EMPTY-FIELD%";
 
     private final String name;
     private final String phone;
@@ -52,11 +55,15 @@ class JsonAdaptedPerson {
     public JsonAdaptedPerson(Person source) {
         name = source.getName().fullName;
         phone = source.getPhone().value;
-        email = source.getEmail().value;
-        address = source.getAddress().value;
+        email = source.getEmail().isEmpty() ? EMPTY_FIELD_FORMAT : source.getEmail().value;
+        address = source.getAddress().isEmpty() ? EMPTY_FIELD_FORMAT : source.getAddress().value;
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+    }
+
+    private boolean isFieldEmpty(String value) {
+        return value.equals(EMPTY_FIELD_FORMAT);
     }
 
     /**
@@ -89,18 +96,26 @@ class JsonAdaptedPerson {
         if (email == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName()));
         }
-        if (!Email.isValidEmail(email)) {
+        final Email modelEmail;
+        if (isFieldEmpty(email)) {
+            modelEmail = Email.createEmpty();
+        } else if (!Email.isValidEmail(email)) {
             throw new IllegalValueException(Email.MESSAGE_CONSTRAINTS);
+        } else {
+            modelEmail = new Email(email);
         }
-        final Email modelEmail = new Email(email);
 
+        final Address modelAddress;
         if (address == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
         }
-        if (!Address.isValidAddress(address)) {
+        if (isFieldEmpty(address)) {
+            modelAddress = Address.createEmpty();
+        } else if (!Address.isValidAddress(address)) {
             throw new IllegalValueException(Address.MESSAGE_CONSTRAINTS);
+        } else {
+            modelAddress = new Address(address);
         }
-        final Address modelAddress = new Address(address);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags);

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -50,8 +50,8 @@ public class PersonCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
-        address.setText(person.getAddress().value);
-        email.setText(person.getEmail().value);
+        address.setText(person.getAddress().getValueForUI());
+        email.setText(person.getEmail().getValueForUI());
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -46,7 +46,7 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_personAcceptedByModel_emptyEmail_addSuccessful() throws Exception {
+    public void execute_personAcceptedByModel_emptyEmail() throws Exception {
         ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
         Person validPerson = new PersonBuilder().withEmptyEmail().build();
 
@@ -58,7 +58,7 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_personAcceptedByModel_emptyAddress_addSuccessful() throws Exception {
+    public void execute_personAcceptedByModel_emptyAddress() throws Exception {
         ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
         Person validPerson = new PersonBuilder().withEmptyAddress().build();
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -46,6 +46,30 @@ public class AddCommandTest {
     }
 
     @Test
+    public void execute_personAcceptedByModel_emptyEmail_addSuccessful() throws Exception {
+        ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
+        Person validPerson = new PersonBuilder().withEmptyEmail().build();
+
+        CommandResult commandResult = new AddCommand(validPerson).execute(modelStub);
+
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
+            commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
+    }
+
+    @Test
+    public void execute_personAcceptedByModel_emptyAddress_addSuccessful() throws Exception {
+        ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
+        Person validPerson = new PersonBuilder().withEmptyAddress().build();
+
+        CommandResult commandResult = new AddCommand(validPerson).execute(modelStub);
+
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
+            commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
+    }
+
+    @Test
     public void execute_duplicatePerson_throwsCommandException() {
         Person validPerson = new PersonBuilder().build();
         AddCommand addCommand = new AddCommand(validPerson);

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -149,14 +149,6 @@ public class AddCommandParserTest {
         assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
                 expectedMessage);
 
-        // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
-
-        // missing address prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
-                expectedMessage);
-
         // all prefixes missing
         assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB,
                 expectedMessage);

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -135,6 +135,16 @@ public class AddCommandParserTest {
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
                 new AddCommand(expectedPerson));
+
+        // empty email
+        Person expectedPerson2 = new PersonBuilder(AMY).withEmptyEmail().withTags().build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY,
+            new AddCommand(expectedPerson2));
+
+        // empty address
+        Person expectedPerson3 = new PersonBuilder(AMY).withEmptyAddress().withTags().build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY,
+            new AddCommand(expectedPerson3));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/AddressTest.java
+++ b/src/test/java/seedu/address/model/person/AddressTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -32,6 +33,17 @@ public class AddressTest {
         assertTrue(Address.isValidAddress("Blk 456, Den Road, #01-355"));
         assertTrue(Address.isValidAddress("-")); // one character
         assertTrue(Address.isValidAddress("Leng Inc; 1234 Market St; San Francisco CA 2349879; USA")); // long address
+    }
+
+    @Test
+    public void emptyAddress() {
+        Address address = Address.createEmpty();
+
+        assertTrue(address.isEmpty());
+
+        assertEquals(address.toString(), "<REPRESENTATION FOR EMPTY ADDRESS>");
+
+        assertEquals(address.getValueForUI(), "No address provided");
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -64,6 +65,17 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
+    }
+
+    @Test
+    public void emptyEmail() {
+        Email email = Email.createEmpty();
+
+        assertTrue(email.isEmpty());
+
+        assertEquals(email.toString(), "<REPRESENTATION FOR EMPTY EMAIL>");
+
+        assertEquals(email.getValueForUI(), "No email provided");
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.storage.JsonAdaptedPerson.EMPTY_FIELD_FORMAT;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
@@ -15,7 +16,9 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.testutil.PersonBuilder;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
@@ -107,4 +110,36 @@ public class JsonAdaptedPersonTest {
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
+    @Test
+    public void toModelType_emptyEmail() throws Exception {
+        List<JsonAdaptedTag> validTags = new ArrayList<>();
+        validTags.add(new JsonAdaptedTag("friend"));
+        Person testPerson = new PersonBuilder().withName(VALID_NAME).withPhone(VALID_PHONE)
+            .withEmptyEmail().withAddress(VALID_ADDRESS).withTags("friend").build();
+
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, EMPTY_FIELD_FORMAT, VALID_ADDRESS, validTags);
+        assertEquals(testPerson, person.toModelType());
+    }
+
+    @Test
+    public void toModelType_emptyAddress() throws Exception {
+        List<JsonAdaptedTag> validTags = new ArrayList<>();
+        validTags.add(new JsonAdaptedTag("friend"));
+        Person testPerson = new PersonBuilder().withName(VALID_NAME).withPhone(VALID_PHONE)
+            .withEmail(VALID_EMAIL).withEmptyAddress().withTags("friend").build();
+
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, EMPTY_FIELD_FORMAT, validTags);
+        assertEquals(testPerson, person.toModelType());
+    }
+
+    @Test
+    public void toModelType_emptyEmail_emptyAddress() throws Exception {
+        List<JsonAdaptedTag> validTags = new ArrayList<>();
+        validTags.add(new JsonAdaptedTag("friend"));
+        Person testPerson = new PersonBuilder().withName(VALID_NAME).withPhone(VALID_PHONE)
+            .withEmptyEmail().withEmptyAddress().withTags("friend").build();
+
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, EMPTY_FIELD_FORMAT, EMPTY_FIELD_FORMAT, validTags);
+        assertEquals(testPerson, person.toModelType());
+    }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -117,7 +117,8 @@ public class JsonAdaptedPersonTest {
         Person testPerson = new PersonBuilder().withName(VALID_NAME).withPhone(VALID_PHONE)
             .withEmptyEmail().withAddress(VALID_ADDRESS).withTags("friend").build();
 
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, EMPTY_FIELD_FORMAT, VALID_ADDRESS, validTags);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+            VALID_NAME, VALID_PHONE, EMPTY_FIELD_FORMAT, VALID_ADDRESS, validTags);
         assertEquals(testPerson, person.toModelType());
     }
 
@@ -128,7 +129,8 @@ public class JsonAdaptedPersonTest {
         Person testPerson = new PersonBuilder().withName(VALID_NAME).withPhone(VALID_PHONE)
             .withEmail(VALID_EMAIL).withEmptyAddress().withTags("friend").build();
 
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, EMPTY_FIELD_FORMAT, validTags);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+            VALID_NAME, VALID_PHONE, VALID_EMAIL, EMPTY_FIELD_FORMAT, validTags);
         assertEquals(testPerson, person.toModelType());
     }
 
@@ -139,7 +141,8 @@ public class JsonAdaptedPersonTest {
         Person testPerson = new PersonBuilder().withName(VALID_NAME).withPhone(VALID_PHONE)
             .withEmptyEmail().withEmptyAddress().withTags("friend").build();
 
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, EMPTY_FIELD_FORMAT, EMPTY_FIELD_FORMAT, validTags);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+            VALID_NAME, VALID_PHONE, EMPTY_FIELD_FORMAT, EMPTY_FIELD_FORMAT, validTags);
         assertEquals(testPerson, person.toModelType());
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -145,4 +145,12 @@ public class JsonAdaptedPersonTest {
             VALID_NAME, VALID_PHONE, EMPTY_FIELD_FORMAT, EMPTY_FIELD_FORMAT, validTags);
         assertEquals(testPerson, person.toModelType());
     }
+
+    @Test
+    public void toModelType_emptyFields_returnsPerson() throws Exception {
+        Person testPerson = new PersonBuilder().withName(VALID_NAME).withPhone(VALID_PHONE)
+            .withEmptyEmail().withEmptyAddress().withTags("friend").build();
+        JsonAdaptedPerson person = new JsonAdaptedPerson(testPerson);
+        assertEquals(testPerson, person.toModelType());
+    }
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -74,6 +74,14 @@ public class PersonBuilder {
     }
 
     /**
+     * Sets an empty {@code Address} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withEmptyAddress() {
+        this.address = Address.createEmpty();
+        return this;
+    }
+
+    /**
      * Sets the {@code Phone} of the {@code Person} that we are building.
      */
     public PersonBuilder withPhone(String phone) {
@@ -86,6 +94,14 @@ public class PersonBuilder {
      */
     public PersonBuilder withEmail(String email) {
         this.email = new Email(email);
+        return this;
+    }
+
+    /**
+     * Sets an empty {@code Email} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withEmptyEmail() {
+        this.email = Email.createEmpty();
         return this;
     }
 


### PR DESCRIPTION
- Added OptionalField interface, EmptyAddress, and EmptyEmail classes
- Updated Parser to handle null inputs for Email and Address (converts to empty)
- Updated saving/loading to handle empty fields
- Updated user guide for optional
- Added test cases

Closes #41 