### PR TITLE
Add filter command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -130,6 +130,28 @@ Examples:
   ![result for 'find alex david'](images/findAlexDavidResult.png)
 * `find Ifan` sorts other names by decreasing similarity to `Ifan` (e.g. Irfan, Isolde, Ayush, ...)
 
+### Filtering persons by criteria: `filter`
+
+Filters the displayed list of persons in the address book to include all persons who meet the specified criteria and displays them with index numbers.
+
+Format: `filter p/PHONE e/EMAIL a/ADDRESS t/TAG...`
+
+Parameters:
+* p/PHONE: The phone number criteria to filter by.
+* e/EMAIL: The email criteria to filter by.
+* a/ADDRESS: The address criteria to filter by.
+* t/TAG...: The tags to filter by.
+
+Examples:
+* `filter p/+65 e/example.com a/Clementi t/Inactive`: Filters the list to include all persons whose phone number contains `+65`, email contains `example.com`, address contains `Clementi`, and have the tag Inactive.
+* `filter p/987 e/johndoe@example.com a/Street`: Filters the list to include all persons whose phone number contains `987`, email is `johndoe@example.com`, and address contains `Street`.
+
+Notes:
+* At least one of p/PHONE, e/EMAIL, or a/ADDRESS must be provided.
+* Multiple criteria for phone, email, address and tags can be specified, separated by spaces.
+* The criteria for phone, email, and address are case-insensitive and can be partial matches.
+* The criteria for tags only checks for exact matches.
+
 ### Deleting a person : `delete`
 
 Deletes the person with the specified `NAME` or the person at the specified `INDEX`

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,0 +1,75 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.PersonMeetsCriteriaPredicate;
+
+/**
+ * Filters the displayed list of persons in the address book to include all persons who meet the specified criteria.
+ */
+public class FilterCommand extends Command {
+
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Filters the displayed list to include all persons who meet "
+            + "the specified criteria and displays them with index numbers.\n"
+            + "Parameters: "
+            + PREFIX_PHONE + "PHONE "
+            + PREFIX_EMAIL + "EMAIL "
+            + PREFIX_ADDRESS + "ADDRESS "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_PHONE + "+65"
+            + PREFIX_EMAIL + "example.com "
+            + PREFIX_ADDRESS + "Clementi"
+            + PREFIX_TAG + "Inactive";
+
+    private final PersonMeetsCriteriaPredicate predicate;
+
+    /**
+     * Constructs a {@code FilterCommand} with the specified predicate.
+     *
+     * @param predicate The predicate used to filter the list of persons.
+     */
+    public FilterCommand(PersonMeetsCriteriaPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FilterCommand)) {
+            return false;
+        }
+
+        FilterCommand otherFilterCommand = (FilterCommand) other;
+        return predicate.equals(otherFilterCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -67,6 +68,9 @@ public class AddressBookParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+        case FilterCommand.COMMAND_WORD:
+            return new FilterCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.PersonMeetsCriteriaPredicate;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new FilterCommand object.
+ */
+public class FilterCommandParser implements Parser<FilterCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FilterCommand
+     * and returns a FilterCommand object for execution.
+     *
+     * @param args The user input arguments.
+     * @return A FilterCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format.
+     */
+    public FilterCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
+
+        List<String> phoneCriteria = new ArrayList<>();
+        if (arePrefixesPresent(argMultimap, PREFIX_PHONE)) {
+            phoneCriteria = ParserUtil.parseCriteria(argMultimap.getValue(PREFIX_PHONE).get().trim());
+        }
+        List<String> emailCriteria = new ArrayList<>();
+        if (arePrefixesPresent(argMultimap, PREFIX_EMAIL)) {
+            emailCriteria = ParserUtil.parseCriteria(argMultimap.getValue(PREFIX_EMAIL).get().trim());
+        }
+
+        List<String> addressCriteria = new ArrayList<>();
+        if (arePrefixesPresent(argMultimap, PREFIX_ADDRESS)) {
+            addressCriteria = ParserUtil.parseCriteria(argMultimap.getValue(PREFIX_ADDRESS).get().trim());
+        }
+
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        return new FilterCommand(
+            new PersonMeetsCriteriaPredicate(phoneCriteria, emailCriteria, addressCriteria, tagList));
+    }
+
+    /**
+     * Returns true if any of the prefixes contains non-empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     *
+     * @param argumentMultimap The ArgumentMultimap containing the prefixes.
+     * @param prefixes The prefixes to check.
+     * @return True if any of the prefixes contain non-empty values, false otherwise.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,8 +2,10 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -126,5 +128,19 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses {@code String criteria} into a {@code List<String>}.
+     */
+    public static List<String> parseCriteria(String criteria) throws ParseException {
+        requireNonNull(criteria);
+        final List<String> criteriaSet = new ArrayList<>();
+        for (String criteriaString : criteria.split(" ")) {
+            if (!criteriaString.isEmpty()) {
+                criteriaSet.add(criteriaString);
+            }
+        }
+        return criteriaSet;
     }
 }

--- a/src/main/java/seedu/address/model/person/PersonMeetsCriteriaPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonMeetsCriteriaPredicate.java
@@ -1,0 +1,90 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Tests that a {@code Person}'s {@code Phone}, {@code Email},
+ * {@code Address}, and {@code Tags} match the given criteria.
+ */
+public class PersonMeetsCriteriaPredicate implements Predicate<Person> {
+    private final List<String> phoneCriteria;
+    private final List<String> emailCriteria;
+    private final List<String> addressCriteria;
+    private final Set<Tag> tags;
+
+    /**
+     * Constructs a {@code PersonMeetsCriteriaPredicate} with the specified criteria.
+     *
+     * @param phoneCriteria The list of phone criteria to match.
+     * @param emailCriteria The list of email criteria to match.
+     * @param addressCriteria The list of address criteria to match.
+     * @param tags The set of tags to match.
+     */
+    public PersonMeetsCriteriaPredicate(
+        List<String> phoneCriteria,
+        List<String> emailCriteria,
+        List<String> addressCriteria,
+        Set<Tag> tags) {
+        this.phoneCriteria = phoneCriteria;
+        this.emailCriteria = emailCriteria;
+        this.addressCriteria = addressCriteria;
+        this.tags = tags;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        boolean phoneMatch = true;
+        boolean tagsMatch = person.getTags().containsAll(tags);
+        boolean emailMatch = true;
+        boolean addressMatch = true;
+
+        if (!phoneCriteria.isEmpty()) {
+            phoneMatch = phoneCriteria.stream()
+                .anyMatch(searchTerm -> StringUtil.containsSubstringIgnoreCase(person.getPhone().value, searchTerm));
+        }
+
+        if (!emailCriteria.isEmpty() && !person.getEmail().isEmpty()) {
+            emailMatch = emailCriteria.stream()
+                .anyMatch(searchTerm -> StringUtil.containsSubstringIgnoreCase(person.getEmail().value, searchTerm));
+        }
+
+        if (!addressCriteria.isEmpty() && !person.getAddress().isEmpty()) {
+            addressMatch = addressCriteria.stream()
+                .anyMatch(searchTerm -> StringUtil.containsSubstringIgnoreCase(person.getAddress().value, searchTerm));
+        }
+
+        return phoneMatch && emailMatch && addressMatch && tagsMatch;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof PersonMeetsCriteriaPredicate)) {
+            return false;
+        }
+
+        PersonMeetsCriteriaPredicate otherPersonMeetsCriteriaPredicate = (PersonMeetsCriteriaPredicate) other;
+        return phoneCriteria.equals(otherPersonMeetsCriteriaPredicate.phoneCriteria)
+            && emailCriteria.equals(otherPersonMeetsCriteriaPredicate.emailCriteria)
+            && addressCriteria.equals(otherPersonMeetsCriteriaPredicate.addressCriteria)
+            && tags.equals(otherPersonMeetsCriteriaPredicate.tags);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .add("phone", phoneCriteria)
+            .add("email", emailCriteria)
+            .add("address", addressCriteria)
+            .add("tags", tags).toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -1,0 +1,116 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.PersonMeetsCriteriaPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindCommand}.
+ */
+public class FilterCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        PersonMeetsCriteriaPredicate firstPredicate =
+                new PersonMeetsCriteriaPredicate(
+                    Arrays.asList(),
+                    Arrays.asList(),
+                    Arrays.asList("first"),
+                    new HashSet<>()
+                );
+        PersonMeetsCriteriaPredicate secondPredicate =
+                new PersonMeetsCriteriaPredicate(
+                    Arrays.asList(),
+                    Arrays.asList(),
+                    Arrays.asList("second"),
+                    new HashSet<>()
+                );
+
+        FilterCommand filterFirstCommand = new FilterCommand(firstPredicate);
+        FilterCommand filterSecondCommand = new FilterCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(filterFirstCommand.equals(filterFirstCommand));
+
+        // same values -> returns true
+        FilterCommand filterFirstCommandCopy = new FilterCommand(firstPredicate);
+        assertTrue(filterFirstCommand.equals(filterFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(filterFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(filterFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(filterFirstCommand.equals(filterSecondCommand));
+    }
+
+    @Test
+    public void execute_emptyCriteria_allListed() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 7);
+        PersonMeetsCriteriaPredicate predicate = preparePredicate(null);
+        FilterCommand command = new FilterCommand(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_hasCriteria_multiplePersonsListed() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        PersonMeetsCriteriaPredicate predicate = preparePredicate("street");
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL, DANIEL, GEORGE), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void toStringMethod() {
+        PersonMeetsCriteriaPredicate predicate = new PersonMeetsCriteriaPredicate(
+                Arrays.asList(),
+                Arrays.asList(),
+                Arrays.asList("address"),
+                new HashSet<>()
+            );
+        FilterCommand filterCommand = new FilterCommand(predicate);
+        String expected = FilterCommand.class.getCanonicalName()
+            + "{predicate=" + predicate + "}";
+        assertEquals(expected, filterCommand.toString());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     */
+    private PersonMeetsCriteriaPredicate preparePredicate(String address) {
+        return address == null
+            ? new PersonMeetsCriteriaPredicate(
+                Arrays.asList(),
+                Arrays.asList(),
+                Arrays.asList(),
+                new HashSet<>()
+            ) : new PersonMeetsCriteriaPredicate(
+                Arrays.asList(),
+                Arrays.asList(),
+                Arrays.asList(address),
+                new HashSet<>()
+            );
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,11 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,12 +25,15 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonMeetsCriteriaPredicate;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -76,6 +84,31 @@ public class AddressBookParserTest {
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords), searchString), command);
+    }
+
+    @Test
+    public void parseCommand_filter() throws Exception {
+        String phoneCriteria = "+65";
+        String emailCriteria = "example.com";
+        String addressCriteria = "Clementi";
+        String tagCriteria = "Inactive";
+
+        String userInput = String.format("%s %s%s %s%s %s%s %s%s",
+                FilterCommand.COMMAND_WORD,
+                PREFIX_PHONE, phoneCriteria,
+                PREFIX_EMAIL, emailCriteria,
+                PREFIX_ADDRESS, addressCriteria,
+                PREFIX_TAG, tagCriteria);
+
+        PersonMeetsCriteriaPredicate predicate = new PersonMeetsCriteriaPredicate(
+                Arrays.asList(phoneCriteria),
+                Arrays.asList(emailCriteria),
+                Arrays.asList(addressCriteria),
+                new HashSet<>(Arrays.asList(new Tag(tagCriteria)))
+        );
+
+        FilterCommand command = (FilterCommand) parser.parseCommand(userInput);
+        assertEquals(new FilterCommand(predicate), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.model.person.PersonMeetsCriteriaPredicate;
+import seedu.address.model.tag.Tag;
+
+public class FilterCommandParserTest {
+    private final FilterCommandParser parser = new FilterCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() throws Exception {
+        String phoneCriteria = "+65";
+        String emailCriteria = "example.com";
+        String addressCriteria = "Clementi";
+        String tagCriteria = "Inactive";
+
+        String userInput = String.format(" %s%s %s%s %s%s %s%s",
+                PREFIX_PHONE, phoneCriteria,
+                PREFIX_EMAIL, emailCriteria,
+                PREFIX_ADDRESS, addressCriteria,
+                PREFIX_TAG, tagCriteria);
+
+        PersonMeetsCriteriaPredicate predicate = new PersonMeetsCriteriaPredicate(
+                Arrays.asList(phoneCriteria),
+                Arrays.asList(emailCriteria),
+                Arrays.asList(addressCriteria),
+                new HashSet<>(Arrays.asList(new Tag(tagCriteria)))
+        );
+
+        assertParseSuccess(parser, userInput, new FilterCommand(predicate));
+    }
+
+    @Test
+    public void parse_optionalFieldsMissing_success() throws Exception {
+        String phoneCriteria = "+65";
+        String userInput = String.format(" %s%s", PREFIX_PHONE, phoneCriteria);
+
+        PersonMeetsCriteriaPredicate predicate = new PersonMeetsCriteriaPredicate(
+                Arrays.asList(phoneCriteria),
+                Arrays.asList(),
+                Arrays.asList(),
+                new HashSet<>()
+        );
+
+        assertParseSuccess(parser, userInput, new FilterCommand(predicate));
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, " invalid input",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_noCriteria_failure() {
+        assertParseFailure(parser, "    ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -192,5 +193,31 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseCriteria_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseCriteria(null));
+    }
+
+    @Test
+    public void parseCriteria_emptyString_returnsEmptyList() throws Exception {
+        assertTrue(ParserUtil.parseCriteria("").isEmpty());
+    }
+
+    @Test
+    public void parseCriteria_multipleCriteria_returnsList() throws Exception {
+        List<String> actualCriteriaList = ParserUtil.parseCriteria("criteria1 criteria2 criteria3");
+        List<String> expectedCriteriaList = Arrays.asList("criteria1", "criteria2", "criteria3");
+
+        assertEquals(expectedCriteriaList, actualCriteriaList);
+    }
+
+    @Test
+    public void parseCriteria_criteriaWithSpaces_returnsTrimmedList() throws Exception {
+        List<String> actualCriteriaList = ParserUtil.parseCriteria("  criteria1  criteria2  ");
+        List<String> expectedCriteriaList = Arrays.asList("criteria1", "criteria2");
+
+        assertEquals(expectedCriteriaList, actualCriteriaList);
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonMeetsCriteriaPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonMeetsCriteriaPredicateTest.java
@@ -1,0 +1,195 @@
+
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.tag.Tag;
+
+public class PersonMeetsCriteriaPredicateTest {
+
+    private final Person person = new Person(
+            new Name("John Doe"),
+            new Phone("12345678"),
+            new Email("john@example.com"),
+            new Address("123 Street"),
+            new HashSet<>(Collections.singleton(new Tag("friend"))));
+
+    @Test
+    public void test_phoneCriteriaMatches_returnsTrue() {
+        List<String> phoneCriteria = Arrays.asList("123");
+        List<String> emailCriteria = Collections.emptyList();
+        List<String> addressCriteria = Collections.emptyList();
+        Set<Tag> tags = Collections.emptySet();
+
+        PersonMeetsCriteriaPredicate predicate = new PersonMeetsCriteriaPredicate(
+            phoneCriteria,
+            emailCriteria,
+            addressCriteria,
+            tags);
+
+        assertTrue(predicate.test(person));
+    }
+
+    @Test
+    public void test_phoneCriteriaDoesNotMatch_returnsFalse() {
+        List<String> phoneCriteria = Arrays.asList("999");
+        List<String> emailCriteria = Collections.emptyList();
+        List<String> addressCriteria = Collections.emptyList();
+        Set<Tag> tags = Collections.emptySet();
+
+        PersonMeetsCriteriaPredicate predicate = new PersonMeetsCriteriaPredicate(
+            phoneCriteria,
+            emailCriteria,
+            addressCriteria,
+            tags);
+
+
+        assertFalse(predicate.test(person));
+    }
+
+    @Test
+    public void test_emailCriteriaMatches_returnsTrue() {
+        List<String> phoneCriteria = Collections.emptyList();
+        List<String> emailCriteria = Arrays.asList("john@example.com");
+        List<String> addressCriteria = Collections.emptyList();
+        Set<Tag> tags = Collections.emptySet();
+
+        PersonMeetsCriteriaPredicate predicate = new PersonMeetsCriteriaPredicate(
+            phoneCriteria,
+            emailCriteria,
+            addressCriteria,
+            tags);
+
+        assertTrue(predicate.test(person));
+    }
+
+    @Test
+    public void test_emailCriteriaDoesNotMatch_returnsFalse() {
+        List<String> phoneCriteria = Collections.emptyList();
+        List<String> emailCriteria = Arrays.asList("jane@example.com");
+        List<String> addressCriteria = Collections.emptyList();
+        Set<Tag> tags = Collections.emptySet();
+
+        PersonMeetsCriteriaPredicate predicate = new PersonMeetsCriteriaPredicate(
+            phoneCriteria,
+            emailCriteria,
+            addressCriteria,
+            tags);
+
+        assertFalse(predicate.test(person));
+    }
+
+    @Test
+    public void test_addressCriteriaMatches_returnsTrue() {
+        List<String> phoneCriteria = Collections.emptyList();
+        List<String> emailCriteria = Collections.emptyList();
+        List<String> addressCriteria = Arrays.asList("Street");
+        Set<Tag> tags = Collections.emptySet();
+
+        PersonMeetsCriteriaPredicate predicate = new PersonMeetsCriteriaPredicate(
+            phoneCriteria,
+            emailCriteria,
+            addressCriteria,
+            tags);
+
+        assertTrue(predicate.test(person));
+    }
+
+    @Test
+    public void test_addressCriteriaDoesNotMatch_returnsFalse() {
+        List<String> phoneCriteria = Collections.emptyList();
+        List<String> emailCriteria = Collections.emptyList();
+        List<String> addressCriteria = Arrays.asList("Avenue");
+        Set<Tag> tags = Collections.emptySet();
+
+        PersonMeetsCriteriaPredicate predicate = new PersonMeetsCriteriaPredicate(
+            phoneCriteria,
+            emailCriteria,
+            addressCriteria,
+            tags);
+
+        assertFalse(predicate.test(person));
+    }
+
+    @Test
+    public void test_tagsMatch_returnsTrue() {
+        List<String> phoneCriteria = Collections.emptyList();
+        List<String> emailCriteria = Collections.emptyList();
+        List<String> addressCriteria = Collections.emptyList();
+        Set<Tag> tags = new HashSet<>(Arrays.asList(new Tag("friend")));
+
+        PersonMeetsCriteriaPredicate predicate = new PersonMeetsCriteriaPredicate(
+            phoneCriteria,
+            emailCriteria,
+            addressCriteria,
+            tags);
+
+        assertTrue(predicate.test(person));
+    }
+
+    @Test
+    public void test_tagsDoNotMatch_returnsFalse() {
+        List<String> phoneCriteria = Collections.emptyList();
+        List<String> emailCriteria = Collections.emptyList();
+        List<String> addressCriteria = Collections.emptyList();
+        Set<Tag> tags = new HashSet<>(Arrays.asList(new Tag("colleague")));
+
+        PersonMeetsCriteriaPredicate predicate = new PersonMeetsCriteriaPredicate(
+            phoneCriteria,
+            emailCriteria,
+            addressCriteria,
+            tags);
+
+        assertFalse(predicate.test(person));
+    }
+
+    @Test
+    public void equals() {
+        List<String> phoneCriteria = Arrays.asList("123");
+        List<String> emailCriteria = Arrays.asList("john@example.com");
+        List<String> addressCriteria = Arrays.asList("123 Street");
+        Set<Tag> tags = new HashSet<>(Arrays.asList(new Tag("friend")));
+
+        PersonMeetsCriteriaPredicate predicate1 = new PersonMeetsCriteriaPredicate(
+            phoneCriteria,
+            emailCriteria,
+            addressCriteria,
+            tags);
+
+        PersonMeetsCriteriaPredicate predicate2 = new PersonMeetsCriteriaPredicate(
+            phoneCriteria,
+            emailCriteria,
+            addressCriteria,
+            tags);
+
+        assertEquals(predicate1, predicate2);
+    }
+
+    @Test
+    public void toStringTest() {
+        List<String> phoneCriteria = Arrays.asList("123");
+        List<String> emailCriteria = Arrays.asList("example.com");
+        List<String> addressCriteria = Arrays.asList("Street");
+        Set<Tag> tags = new HashSet<>(Arrays.asList(new Tag("friend")));
+
+        PersonMeetsCriteriaPredicate predicate = new PersonMeetsCriteriaPredicate(
+            phoneCriteria,
+            emailCriteria,
+            addressCriteria,
+            tags);
+        String expectedString = PersonMeetsCriteriaPredicate.class.getCanonicalName()
+            + "{phone=[123], email=[example.com], address=[Street], tags=[[friend]]}";
+
+        assertEquals(expectedString, predicate.toString());
+    }
+}


### PR DESCRIPTION
- Implemented `FilterCommand` to filter the displayed list of persons
  based on specified criteria.
- Added `FilterCommandParser` to parse input arguments and create a new
  `FilterCommand` object.
- Updated `AddressBookParser` to recognize the new filter command.
- Modified `ParserUtil` to include utility methods for parsing criteria.
- Created `PersonMeetsCriteriaPredicate` to test if a person meets the
  specified criteria.
- Updated test cases.
- Updated user guide.